### PR TITLE
Restructuring install guide

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	// Unfortunately, it is not currently possible to have the same dev container definition for systems with and without a supported GPU.
 	// See also https://github.com/airo-ugent/airo-ros/issues/17.
 	// To enable the container to leverage GPU acceleration, add "--gpus=all" to the list of arguments below.	
-	"runArgs": [ "--net=host", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--gpus=all" ],
+	"runArgs": [ "--net=host", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 	"features": {
 		// Getting a GUI to show content in Chrome (optional - uncomment if needed)
 		// "ghcr.io/devcontainers/features/desktop-lite:1": { "password": "cuda-quantum" }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	// Unfortunately, it is not currently possible to have the same dev container definition for systems with and without a supported GPU.
 	// See also https://github.com/airo-ugent/airo-ros/issues/17.
 	// To enable the container to leverage GPU acceleration, add "--gpus=all" to the list of arguments below.	
-	"runArgs": [ "--net=host", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"runArgs": [ "--net=host", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--gpus=all" ],
 	"features": {
 		// Getting a GUI to show content in Chrome (optional - uncomment if needed)
 		// "ghcr.io/devcontainers/features/desktop-lite:1": { "password": "cuda-quantum" }

--- a/docs/sphinx/api/languages/python_api.rst
+++ b/docs/sphinx/api/languages/python_api.rst
@@ -38,10 +38,10 @@ Program Construction
     .. automethod:: my
     .. automethod:: mz
     .. automethod:: c_if
+    .. automethod:: for_loop
     .. automethod:: adjoint
     .. automethod:: control
     .. automethod:: apply_call
-    .. automethod:: for_loop
     
 Kernel Execution
 =============================

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -172,6 +172,8 @@ The following table summarizes the required components.
       - Linux
     * - Tested Distributions
       - CentOS 8; Debian 11, 12; Fedora 38; OpenSUSE/SELD/SLES 15.5; RHEL 8, 9; Rocky 8, 9; Ubuntu 22.04
+    * - Python versions
+      - 3.9+
 
 .. list-table:: Requirements for GPU Simulation
     :widths: 30 50

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -134,9 +134,9 @@ for all releases `here <https://github.com/NVIDIA/cuda-quantum/releases>`__.
 For more information about building a CUDA Quantum Python wheel from source, see the 
 `README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
 
-The CUDA Quantum Python wheels, by default, do not come installed with our GPU-enabled 
-simulation backends. For further information on installing these GPU simulators with the
-Python wheels, see
+The CUDA Quantum Python wheels, by default, do not come installed with the necessary CUDA
+requirements for GPU-enabled simulation support. For further information on installing these
+extra CUDA dependencies with the Python wheels, see
 `README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
 
 

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -134,6 +134,11 @@ for all releases `here <https://github.com/NVIDIA/cuda-quantum/releases>`__.
 For more information about building a CUDA Quantum Python wheel from source, see the 
 `README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
 
+The CUDA Quantum Python wheels, by default, do not come installed with our GPU-enabled 
+simulation backends. For further information on installing these GPU simulators with the
+Python wheels, see
+`README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
+
 
 Build CUDA Quantum from Source
 ------------------------------

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -134,11 +134,9 @@ for all releases `here <https://github.com/NVIDIA/cuda-quantum/releases>`__.
 For more information about building a CUDA Quantum Python wheel from source, see the 
 `README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
 
-The CUDA Quantum Python wheels, by default, do not come installed with the necessary CUDA
-requirements for GPU-enabled simulation support. For further information on installing these
-extra CUDA dependencies with the Python wheels, see
-`README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
-
+The CUDA Quantum Python wheels expect an existing CUDA installation on the system to make use of GPU-based simulators. 
+For further information on installing CUDA dependencies, 
+see the `README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
 
 Build CUDA Quantum from Source
 ------------------------------

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -139,8 +139,8 @@ For more information about building the entire C++ and Python API's, please see 
 Building from Source
 ------------------------------
 
-For more information about building CUDA Quantum from source, 
-we refer to the `CUDA Quantum GitHub repository`_.
+Instructions for building the Python wheels from source are given in the section :ref:`<install-python-wheels>`.
+For more information about building the entire C++ and Python API from source, we refer to the `CUDA Quantum GitHub repository`_.
 
 .. _CUDA Quantum GitHub repository: https://github.com/NVIDIA/cuda-quantum/blob/main/Building.md
 

--- a/docs/sphinx/install.rst
+++ b/docs/sphinx/install.rst
@@ -118,27 +118,25 @@ or run the Python examples using the Python interpreter.
 Python wheels
 --------------------
 
-CUDA Quantum Python wheels are available on [PyPI.org](https://pypi.org/project/cuda-quantum). 
-The CUDA Quantum Python wheels contain the Python API and core components of
-CUDA Quantum. For more information about available packages and documentation,
+CUDA Quantum Python wheels are available on `PyPI.org <https://pypi.org/project/cuda-quantum>`__. Installation instructions can be found in the `project description <https://pypi.org/project/cuda-quantum/#description>`__.
+For more information about available versions and documentation,
 see :doc:`versions`.
 
-To install the latest release using `pip <https://pypi.org/project/pip/>`__, run
+At this time, wheels are distributed for Linux operating systems only. 
 
-.. code-block:: console
+There are currently no source distributions available on PyPI, but you can download the source code for the latest version of the CUDA Quantum Python wheels from our `GitHub repository <https://github.com/NVIDIA/cuda-quantum>`__. The source code for previous versions can be downloaded from the respective `GitHub Release <https://github.com/NVIDIA/cuda-quantum/releases>`__.
 
-    python3 -m pip install cuda-quantum
+To build the CUDA Quantum Python API from source using pip, run the following commands:
 
-There are currently no source distributions available on PyPI, but you can download the source code 
-for all releases `here <https://github.com/NVIDIA/cuda-quantum/releases>`__. 
-For more information about building a CUDA Quantum Python wheel from source, see the 
-`README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
+```console
+git clone https://github.com/NVIDIA/cuda-quantum.git
+cd cuda-quantum && ./scripts/install_prerequisites.sh
+pip install .
+```
 
-The CUDA Quantum Python wheels expect an existing CUDA installation on the system to make use of GPU-based simulators. 
-For further information on installing CUDA dependencies, 
-see the `README <https://github.com/NVIDIA/cuda-quantum/blob/main/python/README.md>`__.
+For more information about building the entire C++ and Python API's, please see `Building from Source`_.
 
-Build CUDA Quantum from Source
+Building from Source
 ------------------------------
 
 For more information about building CUDA Quantum from source, 
@@ -147,16 +145,18 @@ we refer to the `CUDA Quantum GitHub repository`_.
 .. _CUDA Quantum GitHub repository: https://github.com/NVIDIA/cuda-quantum/blob/main/Building.md
 
 
-CUDA Quantum Dependencies
--------------------------
+.. _dependencies-and-compatibility:
 
-CUDA Quantum can be used to simulate quantum programs (see :doc:`using/simulators`) on a CPU-only system, but a GPU is highly recommended.
+Dependencies and Compatibility
+--------------------------------
+
+CUDA Quantum can be used to compile and run quantum programs on a CPU-only system, but a GPU is highly recommended and necessary to use the GPU-based simulators, see also :doc:`using/simulators`.
 
 The supported CPUs include x86_64 (x86-64-v3 architecture and newer) and ARM64 architectures.
 
 .. note:: 
 
-   The CUDA Quantum Python wheels depend on an existing CUDA installation on your system. For more information about installing the CUDA Quantum Python wheels, take a look at :ref:`this page <install-python-wheels>`.
+   Some of the components included in the CUDA Quantum Python wheels depend on an existing CUDA installation on your system. For more information about installing the CUDA Quantum Python wheels, take a look at :ref:`this section <install-python-wheels>`.
 
 The following table summarizes the required components.
 

--- a/docs/sphinx/releases.rst
+++ b/docs/sphinx/releases.rst
@@ -8,6 +8,7 @@ The latest version of CUDA Quantum is on the main branch of our `GitHub reposito
 
 - `Docker image (nightly builds) <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nightly/containers/cuda-quantum>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/latest>`__
+- `Examples <https://github.com/NVIDIA/cuda-quantum/tree/main/docs/sphinx/examples>`__
 
 **0.4.1**
 
@@ -16,6 +17,7 @@ The 0.4.1 release adds support for ARM processors in the form of multi-platform 
 - `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.4.1>`__
+- `Examples <https://github.com/NVIDIA/cuda-quantum/tree/releases/v0.4.1/docs/sphinx/examples>`__
 
 The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/releases>`__.
 
@@ -30,6 +32,7 @@ The fully featured version is available as a Docker image for `linux/amd64` plat
 - `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
 - `Python wheel <https://pypi.org/project/cuda-quantum/0.4.0>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.4.0>`__
+- `Examples <https://github.com/NVIDIA/cuda-quantum/tree/0.4.0/docs/sphinx/examples>`__
 
 The full change log can be found `here <https://github.com/NVIDIA/cuda-quantum/releases/tag/0.4.0>`__.
 
@@ -39,3 +42,4 @@ The 0.3.0 release of CUDA Quantum is available as a Docker image for `linux/amd6
 
 - `Docker image <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-quantum/tags>`__
 - `Documentation <https://nvidia.github.io/cuda-quantum/0.3.0>`__
+- `Examples <https://github.com/NVIDIA/cuda-quantum/tree/0.3.0/docs/sphinx/examples>`__

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -90,3 +90,29 @@ options to :code:`nvq++`
 .. code:: bash 
 
     nvq++ --target tensornet src.cpp ...
+
+GPU Simulation Requirements
+==================================
+
+For programmers using the CUDA Quantum Python wheels, extra configuration is needed to install
+our GPU enabled simulation backends. 
+
+The system level dependencies for these backends include:
+* An NVIDIA GPU with compute capability 7.0+
+* Driver: Linux (450.80.02+ for CUDA 11, 525.60.13+ for CUDA 12)
+* CUDA Toolkit 11.x or newer
+* Python 3.9+
+
+For Linux users, these system requirements may be installed via 
+
+.. code:: bash
+
+    todo ...
+
+Note: After installing the CUDA Toolkit, you must follow these `post-installation instructions 
+<https://docs.nvidia.com/cuda/archive/11.8.0/cuda-installation-guide-linux/index.html#post-installation-actions>`__.
+
+Python Requirements (pip installation recommended):
+* cutensor-cu11
+* nvidia-cublas-cu11
+* nvidia-cusolver-cu11

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -100,17 +100,12 @@ our GPU enabled simulation backends.
 System Level Dependencies
 ++++++++++++++++++++++++++
 
-The system level dependencies for these backends include:
-* An NVIDIA GPU with compute capability 7.0+
-* Driver: Linux (450.80.02+ for CUDA 11, 525.60.13+ for CUDA 12)
-* CUDA Toolkit 11.x or newer
-* Python 3.9+
+The system level dependencies for these backends may be found in :doc:`CUDA Quantum Dependencies <using/install>`.
 
-For more information on the installation of NVIDIA Driver's for Ubuntu, see
-`here <https://help.ubuntu.com/community/NvidiaDriversInstallation>`__.
+Note: The minimum supported Python version for GPU simulation is Python 3.9.
 
-For installation of the CUDA toolkit, programmers have two options. The first
-is to install the entire CUDA toolkit via your system package manager. For example
+For installation of the CUDA toolkit, programmers have two options. The first is to install the
+entire CUDA toolkit via your system package manager. For example
 
 .. code:: bash
 
@@ -118,19 +113,21 @@ is to install the entire CUDA toolkit via your system package manager. For examp
     # -- or -- 
     dnf install cuda-11-8.x86_64 # RHEL 9
 
-Note: After installing the CUDA Toolkit, you must follow these `post-installation instructions
-<https://docs.nvidia.com/cuda/archive/11.8.0/cuda-installation-guide-linux/index.html#post-installation-actions>`__.
+Note: After installing the CUDA Toolkit, these `post-installation instructions
+<https://docs.nvidia.com/cuda/archive/11.8.0/cuda-installation-guide-linux/index.html#post-installation-actions>`__
+must be followed to ensure the CUDA install may be found in the :code:`LD_LIBRARY_PATH`.
 
 Alternatively, the programmer may install the following Python packages:
-* nvidia-nvtx-vcu11 
+* nvidia-nvtx-cu11 
 * nvidia-cuda-runtime-cu11
 
-You must then export the location of the .so files for these packages to your :code:`LD_LIBRARY_PATH`.
-To find the local installation path of these packages, you may run 
+The location of the installed .so files for these packages must then be exported to
+the :code:`LD_LIBRARY_PATH`. To find the local installation path of these packages,
+assuming installation via pip, programmers may run
 
 .. code::bash
 
-    python3 -m pip show nvidia-nvtx-vcu11 nvidia-cuda-runtime-cu11
+    python3 -m pip show nvidia-nvtx-cu11 nvidia-cuda-runtime-cu11
 
 Python Requirements
 ++++++++++++++++++++

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -95,7 +95,10 @@ GPU Simulation Requirements
 ==================================
 
 For programmers using the CUDA Quantum Python wheels, extra configuration is needed to install
-our GPU enabled simulation backends. 
+our GPU enabled simulation backends.
+
+System Level Dependencies
+++++++++++++++++++++++++++
 
 The system level dependencies for these backends include:
 * An NVIDIA GPU with compute capability 7.0+
@@ -103,16 +106,54 @@ The system level dependencies for these backends include:
 * CUDA Toolkit 11.x or newer
 * Python 3.9+
 
-For Linux users, these system requirements may be installed via 
+For more information on the installation of NVIDIA Driver's for Ubuntu, see
+`here <https://help.ubuntu.com/community/NvidiaDriversInstallation>`__.
+
+For installation of the CUDA toolkit, programmers have two options. The first
+is to install the entire CUDA toolkit via your system package manager. For example
 
 .. code:: bash
 
-    todo ...
+    apt-get install cuda-11-8 # Ubuntu
+    # -- or -- 
+    dnf install cuda-11-8.x86_64 # RHEL 9
 
-Note: After installing the CUDA Toolkit, you must follow these `post-installation instructions 
+Note: After installing the CUDA Toolkit, you must follow these `post-installation instructions
 <https://docs.nvidia.com/cuda/archive/11.8.0/cuda-installation-guide-linux/index.html#post-installation-actions>`__.
 
-Python Requirements (pip installation recommended):
+Alternatively, the programmer may install the following Python packages:
+* nvidia-nvtx-vcu11 
+* nvidia-cuda-runtime-cu11
+
+You must then export the location of the .so files for these packages to your :code:`LD_LIBRARY_PATH`.
+To find the local installation path of these packages, you may run 
+
+.. code::bash
+
+    python3 -m pip show nvidia-nvtx-vcu11 nvidia-cuda-runtime-cu11
+
+Python Requirements
+++++++++++++++++++++
+
+The python requirements for these backends include:
 * cutensor-cu11
+* custatevec-cu11
 * nvidia-cublas-cu11
 * nvidia-cusolver-cu11
+
+We recommend that these be installed via pip:
+
+.. code:: bash
+
+    python3 -m pip install cutensor-cu11 custatevec-cu11 nvidia-cublas-cu11 nvidia-cusolver-cu11
+
+Additionally, for use of the :code:`nvidia-mgpu` backend, the programmer must have a working
+installation of MPI, with the dynamic library :code:`libmpi.so` accessible via the
+:code:`LD_LIBRARY_PATH`.
+
+.. code:: bash
+
+    apt-get install openmpi # Ubuntu
+    # -- or --
+    dnf install openmpi # RHEL 9
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64/openmpi/lib/

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -28,6 +28,10 @@ In python, this can be specified with
 By default, this will leverage :code:`FP32` floating point types for the simulation. To 
 switch to :code:`FP64`, specify the :code:`nvidia-fp64` target instead. 
 
+.. note:: 
+
+    This backend requires an NVIDIA GPU and CUDA runtime libraries. See the section :ref:`<dependencies-and-compatibility>` for more information.
+
 cuQuantum multi-node multi-GPU
 ++++++++++++++++++++++++++++++++++
 
@@ -48,6 +52,10 @@ In python, this can be specified with
 
     cudaq.set_target('nvidia-mgpu')
 
+.. note:: 
+
+    This backend requires an NVIDIA GPU, CUDA runtime libraries, as well as an MPI installation. See the section :ref:`<dependencies-and-compatibility>` for more information.
+
 OpenMP CPU-only
 ++++++++++++++++++++++++++++++++++
 
@@ -65,6 +73,10 @@ cuQuantum multi-node multi-GPU
 The :code:`tensornet` target provides a tensor-network simulator accelerated with 
 the :code:`cuTensorNet` library. This backend is currently available for use from C++ and supports 
 Multi-Node, Multi-GPU distribution of tensor operations required to evaluate and simulate the circuit.
+
+.. note:: 
+
+    This backend requires an NVIDIA GPU and CUDA runtime libraries. See the section :ref:`<dependencies-and-compatibility>` for more information.
 
 This backend exposes a set of environment variables to configure specific aspects of the simulation:
 
@@ -91,66 +103,3 @@ options to :code:`nvq++`
 
     nvq++ --target tensornet src.cpp ...
 
-GPU Simulation Requirements
-==================================
-
-For programmers using the CUDA Quantum Python wheels, extra configuration is needed to install
-our GPU enabled simulation backends.
-
-System Level Dependencies
-++++++++++++++++++++++++++
-
-The system level dependencies for these backends may be found in :doc:`CUDA Quantum Dependencies <using/install>`.
-
-Note: The minimum supported Python version for GPU simulation is Python 3.9.
-
-For installation of the CUDA toolkit, programmers have two options. The first is to install the
-entire CUDA toolkit via your system package manager. For example
-
-.. code:: bash
-
-    apt-get install cuda-11-8 # Ubuntu
-    # -- or -- 
-    dnf install cuda-11-8.x86_64 # RHEL 9
-
-Note: After installing the CUDA Toolkit, these `post-installation instructions
-<https://docs.nvidia.com/cuda/archive/11.8.0/cuda-installation-guide-linux/index.html#post-installation-actions>`__
-must be followed to ensure the CUDA install may be found in the :code:`LD_LIBRARY_PATH`.
-
-Alternatively, the programmer may install the following Python packages:
-* nvidia-nvtx-cu11 
-* nvidia-cuda-runtime-cu11
-
-The location of the installed .so files for these packages must then be exported to
-the :code:`LD_LIBRARY_PATH`. To find the local installation path of these packages,
-assuming installation via pip, programmers may run
-
-.. code:: bash
-
-    python3 -m pip show nvidia-nvtx-cu11 nvidia-cuda-runtime-cu11
-
-Python Requirements
-++++++++++++++++++++
-
-The python requirements for these backends include:
-- cutensor-cu11
-- custatevec-cu11
-- nvidia-cublas-cu11
-- nvidia-cusolver-cu11
-
-We recommend that these be installed via pip:
-
-.. code:: bash
-
-    python3 -m pip install cutensor-cu11 custatevec-cu11 nvidia-cublas-cu11 nvidia-cusolver-cu11
-
-Additionally, for use of the :code:`nvidia-mgpu` backend, the programmer must have a working
-installation of MPI, with the dynamic library :code:`libmpi.so` accessible via the
-:code:`LD_LIBRARY_PATH`.
-
-.. code:: bash
-
-    apt-get install openmpi # Ubuntu
-    # -- or --
-    dnf install openmpi # RHEL 9
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64/openmpi/lib/

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -125,7 +125,7 @@ The location of the installed .so files for these packages must then be exported
 the :code:`LD_LIBRARY_PATH`. To find the local installation path of these packages,
 assuming installation via pip, programmers may run
 
-.. code::bash
+.. code:: bash
 
     python3 -m pip show nvidia-nvtx-cu11 nvidia-cuda-runtime-cu11
 
@@ -133,11 +133,10 @@ Python Requirements
 ++++++++++++++++++++
 
 The python requirements for these backends include:
-
-* cutensor-cu11
-* custatevec-cu11
-* nvidia-cublas-cu11
-* nvidia-cusolver-cu11
+- cutensor-cu11
+- custatevec-cu11
+- nvidia-cublas-cu11
+- nvidia-cusolver-cu11
 
 We recommend that these be installed via pip:
 

--- a/docs/sphinx/using/simulators.rst
+++ b/docs/sphinx/using/simulators.rst
@@ -133,6 +133,7 @@ Python Requirements
 ++++++++++++++++++++
 
 The python requirements for these backends include:
+
 * cutensor-cu11
 * custatevec-cu11
 * nvidia-cublas-cu11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,6 @@ Releases = "https://nvidia.github.io/cuda-quantum/latest/releases.html"
 
 [project.optional-dependencies]
 chemistry = [ "scipy==1.10.1", "openfermionpyscf==0.5" ]
-cudart = [
-  # cublas is (the only library) need for the simulators but available for x86_64 only
-  'nvidia-cublas-cu11 ~= 11.11',
-  'nvidia-cusolver-cu11 ~= 11.4',
-  'nvidia-cusparse-cu11 ~= 11.7',
-  'nvidia-cuda-runtime-cu11 ~= 11.8'
-]
 
 [build-system]
 requires = ["scikit-build-core", "cmake>=3.26"]

--- a/python/README.md
+++ b/python/README.md
@@ -72,7 +72,6 @@ To install and configure GPU enabled simulation backends, see
 [python_gpu_reference]:
     https://nvidia.github.io/cuda-quantum/latest/using/simulators.html#gpu-simulation-requirements
 
-
 ## Contributing
 
 There are many ways in which you can get involved with CUDA Quantum. If you are

--- a/python/README.md
+++ b/python/README.md
@@ -62,10 +62,16 @@ result = cudaq.sample(kernel)
 To see more examples, go to [python examples][python_examples], or check out the
 [Python API reference][python_api_reference].
 
+To install and configure GPU enabled simulation backends, see 
+[Configuring GPU Backends][python_gpu_reference].
+
 [python_examples]:
     https://nvidia.github.io/cuda-quantum/latest/using/python.html
 [python_api_reference]:
     https://nvidia.github.io/cuda-quantum/latest/api/languages/python_api.html
+[python_gpu_reference]:
+    https://nvidia.github.io/cuda-quantum/latest/using/simulators.html#gpu-simulation-requirements
+
 
 ## Contributing
 

--- a/python/README.md
+++ b/python/README.md
@@ -13,33 +13,52 @@ computing, including CUDA, ISO standard parallelism, OpenMP, and OpenACC
   cuQuantum and a number of different physical quantum processors (QPUs)
 
 The CUDA Quantum Python wheels contain the Python API and core components of
-CUDA Quantum. For more information about available packages and documentation,
-see our [release
-notes](https://nvidia.github.io/cuda-quantum/latest/releases.html).
+CUDA Quantum. More information about available packages as well as a link to the
+documentation and examples for each version can be found in the [release
+notes][cudaq_docs_releases]. System requirements and compatibility are listed in
+the Getting Started section of the linked documentation.
+
+[cudaq_docs_releases]:
+    https://nvidia.github.io/cuda-quantum/latest/releases.html
 
 ## Installing CUDA Quantum
 
-CUDA Quantum Python wheels are available on
-[PyPI.org](https://pypi.org/project/cuda-quantum). To install the latest
-release, simply run
+To install the latest stable version of CUDA Quantum, run
 
 ```console
-pip install cuda-quantum
+python3 -m pip install cuda-quantum
 ```
 
-At this time, wheels are distributed for Linux operating systems only. To build
-the CUDA Quantum Python API from source using pip:
+CUDA Quantum can be used to compile and run quantum programs on a CPU-only
+system, but a GPU is highly recommended and necessary to use the some of the
+simulators. The GPU-based simulators included in the CUDA Quantum Python wheels
+require an existing CUDA installation. Additionally, multi-GPU simulators
+require an existing MPI installation.
+
+In most cases, the CUDA and MPI dependencies can be installed via package
+manager. On Ubuntu 22.04, for example, the following commands install all
+optional CUDA dependencies:
 
 ```console
-git clone https://github.com/NVIDIA/cuda-quantum.git
-cd cuda-quantum && ./scripts/install_prerequisites.sh
-pip install .
+  arch=x86_64 # set this to sbsa for ARM processors
+  sudo apt-get update && sudo apt-get install -y wget
+  wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/$arch/cuda-keyring_1.0-1_all.deb
+  sudo dpkg -i cuda-keyring_1.0-1_all.deb
+  sudo apt-get update && sudo apt-get install -y cuda-11-8
 ```
 
-For more information about building the entire C++ and Python API's, please see
-the CUDA Quantum [documentation][official_install].
+Detailed instructions for how to install the complete CUDA toolkit on different
+operating systems can be found in the [CUDA
+documentation](https://docs.nvidia.com/cuda/). 
 
-[official_install]: https://nvidia.github.io/cuda-quantum/latest/install.html
+If you have several GPUs available but no MPI installation yet, we recommend
+taking a look at the [OpenMPI documentation](https://docs.open-mpi.org/). On
+Ubuntu 22.04, for example, the following commands install the necessary MPI
+libraries:
+
+```console
+  sudo apt-get update && sudo apt-get install openmpi
+```
 
 ## Running CUDA Quantum
 
@@ -57,20 +76,8 @@ kernel.mz(qubit)
 result = cudaq.sample(kernel)
 ```
 
-## Documentation
-
-To see more examples, go to [python examples][python_examples], or check out the
-[Python API reference][python_api_reference].
-
-To install and configure GPU enabled simulation backends, see
-[Configuring GPU Backends][python_gpu_reference].
-
-[python_examples]:
-    https://nvidia.github.io/cuda-quantum/latest/using/python.html
-[python_api_reference]:
-    https://nvidia.github.io/cuda-quantum/latest/api/languages/python_api.html
-[python_gpu_reference]:
-    https://nvidia.github.io/cuda-quantum/latest/using/simulators.html#gpu-simulation-requirements
+Additional examples and documentation are linked in the [release
+notes][cudaq_docs_releases].
 
 ## Contributing
 

--- a/python/README.md
+++ b/python/README.md
@@ -62,7 +62,7 @@ result = cudaq.sample(kernel)
 To see more examples, go to [python examples][python_examples], or check out the
 [Python API reference][python_api_reference].
 
-To install and configure GPU enabled simulation backends, see 
+To install and configure GPU enabled simulation backends, see
 [Configuring GPU Backends][python_gpu_reference].
 
 [python_examples]:


### PR DESCRIPTION
This PR makes the following changes:
- In 0.4.0, I wasn't very careful with links in the readme, such that these links refer to the latest version of the docs. Since this can cause confusion, I updated it to only directly link to the release notes.
- The release notes contain links to the docs and examples for each version.
- I removed the instructions for building from source from the PyPI readme and instead added them to the docs (specifically to the Python Wheels section of the Getting Started page).
- I removed the instructions for installing wheel dependencies from the docs and instead added them to the PyPI readme.
- I removed updates to the simulators that give instructions for installing dependencies and instead added a note for the backend that states what optional components are needed.
- I removed the optional cudart dependencies in the Python wheel. Even with all of these packages installed, there are still some libraries that will need to be installed separately (that aren't available on PyPI), and it just seems better to have a (one!) simple and clear recommendation for how to install the optional dependencies in the readme. If the simple instructions are not enough, I linked the CUDA docs and the OpenMPI docs for more information.

Not done: I haven't updated the mgpu docs with instructions for how to run the code (that's something for another PR...)